### PR TITLE
Add X-Forwarded-Proto header

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -707,6 +707,14 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	} else {
 		rw.Header().Set("GAP-Auth", session.Email)
 	}
+	switch {
+	case p.redirectURL.Scheme != "":
+		req.Header.Set("X-Forwarded-Proto", p.redirectURL.Scheme)
+	case p.CookieSecure:
+		req.Header.Set("X-Forwarded-Proto", "https")
+	default:
+		req.Header.Set("X-Forwarded-Proto", "http")
+	}
 	return http.StatusAccepted
 }
 


### PR DESCRIPTION
Guess protocol from redirect-url scheme if present, or from
cookie-secure flag value.

closes bitly/oauth2_proxy#171
bitly/oauth2_proxy#177